### PR TITLE
Switch to guids being unlinked from podcast urls

### DIFF
--- a/content/episode/0-coming-soon.md
+++ b/content/episode/0-coming-soon.md
@@ -2,7 +2,8 @@
 title: "Coming soon"
 episode: "0"
 Description: "The Harvest Season: Coming Soon"
-podcast: "ths-0.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-0.mp3"
+podcast: "ths/ths-0.mp3"
 podcast_bytes: "627702"
 podcast_duration: "00:00:36"
 date: 2018-12-31T09:00:00+00:00
@@ -16,4 +17,4 @@ The Harvest Season is a new podcast from Al McKinlay and Raschelle Dellaney.
 
 It'll cover farming games, what we like, what we play, what we dislike, our favourites.
 
-Coming in 2019. 
+Coming in 2019.

--- a/content/episode/1-1-1-intro.md
+++ b/content/episode/1-1-1-intro.md
@@ -2,12 +2,13 @@
 title: "New Beginnings"
 episode: "Spring 1"
 Description: "We talk about who we are, and what the podcast will be about."
-podcast: "ths-1-1-1.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-1.mp3"
+podcast: "ths/year1/spring/ths-1-1-01.mp3"
 podcast_bytes: "21028835"
 podcast_duration: "00:29:34"
 date: 2019-01-09T21:00:00+00:00
 
-author: "Al McKinlay and Raschelle Dellaney" 
+author: "Al McKinlay and Raschelle Dellaney"
 aliases: []
 categories: []
 ---
@@ -19,7 +20,7 @@ categories: []
 [07:13] Who are we
 [17:00] Our favourite games
 [20:19] What are we playing?
-[24:11] What are we looking forward to? 
+[24:11] What are we looking forward to?
 [27:44] Outro
 
 ## Links

--- a/content/episode/1-1-10-tot-challenge.md
+++ b/content/episode/1-1-10-tot-challenge.md
@@ -2,7 +2,8 @@
 title: "The Best Soybeans in the World"
 episode: "Spring 10"
 Description: "We talk about our Trio of Towns challenge. Who will win this one?"
-podcast: "ths-1-1-10.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-10.mp3"
+podcast: "ths/year1/spring/ths-1-1-10.mp3"
 podcast_bytes: "67967267"
 podcast_duration: "01:10:47"
 date: 2019-05-15T20:00:00+00:00

--- a/content/episode/1-1-11-mods.md
+++ b/content/episode/1-1-11-mods.md
@@ -2,7 +2,8 @@
 title: "Mods mods mods"
 episode: "Spring 11"
 Description: "We talk about Farming Game mods. What are they? What games have them? What are our favourite ones?"
-podcast: "ths-1-1-11.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-11.mp3"
+podcast: "ths/year1/spring/ths-1-1-11.mp3"
 podcast_bytes: "76778683"
 podcast_duration: "1:19:58"
 date: 2019-05-29T20:00:00+00:00

--- a/content/episode/1-1-12-future-games.md
+++ b/content/episode/1-1-12-future-games.md
@@ -1,8 +1,9 @@
 ---
 title: "The Expert at Being Mildly Satisfied"
 episode: "Spring 12"
-Description: "We talk about "
-podcast: "ths-1-1-12.mp3"
+Description: "We talk about games we are loking forward to coming out"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-12.mp3"
+podcast: "ths/year1/spring/ths-1-1-12.mp3"
 podcast_bytes: "46786768"
 podcast_duration: "48:44"
 date: 2019-06-12T20:00:00+00:00

--- a/content/episode/1-1-13-doraemon-sos-demo.md
+++ b/content/episode/1-1-13-doraemon-sos-demo.md
@@ -2,7 +2,8 @@
 title: "The Hat is Evil"
 episode: "Spring 13"
 Description: "We talk about the demo for Doraemon Story of Seaons, and initial thoughts on the game."
-podcast: "ths-1-1-13.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-13.mp3"
+podcast: "ths/year1/spring/ths-1-1-13.mp3"
 podcast_bytes: "60820165"
 podcast_duration: "01:03:21"
 date: 2019-06-26T20:00:00+00:00

--- a/content/episode/1-1-14-minecraft.md
+++ b/content/episode/1-1-14-minecraft.md
@@ -3,6 +3,8 @@ title: "A Very Well Structured Episode"
 episode: "Spring 14"
 Description: "We talk about Minecraft, and why it is, infact, a farming game."
 podcast: "ths-1-1-14.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-14.mp3"
+podcast: "ths/year1/spring/ths-1-1-14.mp3"
 podcast_bytes: "73026245"
 podcast_duration: "01:16:04"
 date: 2019-07-10T20:00:00+00:00

--- a/content/episode/1-1-2-stardew.md
+++ b/content/episode/1-1-2-stardew.md
@@ -2,7 +2,8 @@
 title: "Meeting the Villagers"
 episode: "Spring 2"
 Description: "We talk about one of the biggest farming games, and an indie sensation of the last few years ... stardew valley"
-podcast: "ths-1-1-2.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-2.mp3"
+podcast: "ths/year1/spring/ths-1-1-02.mp3"
 podcast_bytes: "67082030"
 podcast_duration: "01:09:52"
 date: 2019-01-23T21:00:00+00:00
@@ -42,7 +43,6 @@ Stardew 1.1 update: https://www.stardewvalley.net/stardew-valley-v1-1-changelog/
 Stardew 1.2 update: https://www.stardewvalley.net/stardew-valley-1-2-is-here/
 Stardew 1.3 update: https://www.stardewvalley.net/stardew-valley-1-3-multiplayer-update-is-now-available/
 "What's in store for Stardew Valley": https://www.stardewvalley.net/whats-in-store-for-stardew-valley/
-
 
 Transcript: https://docs.google.com/document/d/1L2MERbwAIgnHKs4AyfYYFtVsbMElGoKynL5cz92FYQg/edit?usp=sharing
 

--- a/content/episode/1-1-3-stardew-multiplayer.md
+++ b/content/episode/1-1-3-stardew-multiplayer.md
@@ -2,7 +2,8 @@
 title: "Farming With Friends"
 episode: "Spring 3"
 Description: "We talk about the newest update for Stardew Valley, including the multiplayer functionality"
-podcast: "ths-1-1-3.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-3.mp3"
+podcast: "ths/year1/spring/ths-1-1-03.mp3"
 podcast_bytes: "70143854"
 podcast_duration: "01:08:09"
 date: 2019-02-06T21:00:00+00:00
@@ -19,7 +20,7 @@ author: "Al McKinlay and Raschelle Dellaney"
 [24:50] Stardew 1.3 update intro
 [29:18] Intro to multiplayer
 [39:29] New single player content
-[55:36] Multiplayer opinions 
+[55:36] Multiplayer opinions
 [1:04:00] Stardew Challenge (next episode)
 [1:06:14] Outro
 

--- a/content/episode/1-1-4-stardew-challenge.md
+++ b/content/episode/1-1-4-stardew-challenge.md
@@ -2,7 +2,8 @@
 title: "Mining is a Dangerous Profession"
 episode: "Spring 4"
 Description: "Raschelle and Al talk about their first Challenge, mining in Stardew."
-podcast: "ths-1-1-4.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-4.mp3"
+podcast: "ths/year1/spring/ths-1-1-04.mp3"
 podcast_bytes: "65636050"
 podcast_duration: "01:05:37"
 date: 2019-02-20T21:00:00+00:00

--- a/content/episode/1-1-5-trio-of-towns-intro.md
+++ b/content/episode/1-1-5-trio-of-towns-intro.md
@@ -2,7 +2,8 @@
 title: "Read All About It"
 episode: "Spring 5"
 Description: "An introduction to Story of Seasons: Trio of Towns, a whole lot of news, and some discussion about Pokémon."
-podcast: "ths-1-1-5.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-5.mp3"
+podcast: "ths/year1/spring/ths-1-1-05.mp3"
 podcast_bytes: "61613823"
 podcast_duration: "01:00:38"
 date: 2019-03-06T21:00:00+00:00

--- a/content/episode/1-1-6-factory-town.md
+++ b/content/episode/1-1-6-factory-town.md
@@ -2,7 +2,8 @@
 title: "Automate All The Things!!"
 episode: "Spring 6"
 Description: "Al and Raschelle look at the new game Factory Town. Raschelle gets addicted."
-podcast: "ths-1-1-6.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-6.mp3"
+podcast: "ths/year1/spring/ths-1-1-06.mp3"
 podcast_bytes: "75021164"
 podcast_duration: "01:18:08"
 date: 2019-03-20T21:00:00+00:00
@@ -25,7 +26,7 @@ You can get Factory Town on Steam now. https://store.steampowered.com/app/860890
 
 The Good Life: https://www.kickstarter.com/projects/476090608/the-good-life/
 Forager on mobile screenshot: https://twitter.com/_HopFrog/status/1103330053423841283
-Confirmation of Forager coming to mobile: https://twitter.com/_HopFrog/status/1103681095197970434 
+Confirmation of Forager coming to mobile: https://twitter.com/_HopFrog/status/1103681095197970434
 Farm Folks development roadmap: https://trello.com/b/i8jAzlrv/farm-folks-development-roadmap
 Islanders: https://twitter.com/_grizzlygames/status/1105135020128256000?s=09
 

--- a/content/episode/1-1-7-tot-story.md
+++ b/content/episode/1-1-7-tot-story.md
@@ -2,7 +2,8 @@
 title: "100 Years Of Characters"
 episode: "Spring 7"
 Description: "We look at Trio of Towns, and discuss the underlying story and all about the characters."
-podcast: "ths-1-1-7.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-7.mp3"
+podcast: "ths/year1/spring/ths-1-1-07.mp3"
 podcast_bytes: "124578167"
 podcast_duration: "02:09:46"
 date: 2019-04-03T20:00:00+00:00

--- a/content/episode/1-1-8-tot-mechanics.md
+++ b/content/episode/1-1-8-tot-mechanics.md
@@ -2,7 +2,8 @@
 title: "100 years of Mechanics"
 episode: "Spring 8"
 Description: "We look at Trio of Towns, and discuss the mechanics and how you play the game."
-podcast: "ths-1-1-8.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-8.mp3"
+podcast: "ths/year1/spring/ths-1-1-08.mp3"
 podcast_bytes: "107697213"
 podcast_duration: "1:52:11"
 date: 2019-04-17T20:00:00+00:00

--- a/content/episode/1-1-9-tot-calendar.md
+++ b/content/episode/1-1-9-tot-calendar.md
@@ -2,7 +2,8 @@
 title: "100 Years of Festivals"
 episode: "Spring 9"
 Description: "We discuss all the calendar related events in Story of Seasons: Trio of Towns"
-podcast: "ths-1-1-9.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/ths-1-1-9.mp3"
+podcast: "ths/year1/spring/ths-1-1-09.mp3"
 podcast_bytes: "70046383"
 podcast_duration: "01:08:33"
 date: 2019-05-01T20:00:00+00:00


### PR DESCRIPTION
We add the old episodes guids to be the existing urls though, otherwise podcast clients will re-download everything.